### PR TITLE
Move example program into examples folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,5 @@ func main() {
 }
 ```
 
-See [internal/cmd/cmd.go](internal/cmd/cmd.go) and
+See [examples/tnd/main.go](examples/tnd/main.go) and
 [scripts/tnd.sh](scripts/tnd.sh) for a complete example.

--- a/cmd/tnd/main.go
+++ b/cmd/tnd/main.go
@@ -1,7 +1,0 @@
-package main
-
-import "github.com/T-Systems-MMS/tnd/internal/cmd"
-
-func main() {
-	cmd.Run()
-}

--- a/examples/tnd/main.go
+++ b/examples/tnd/main.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"flag"
@@ -36,8 +36,7 @@ func parseCommandLine() {
 	}
 }
 
-// Run is the main entry point
-func Run() {
+func main() {
 	// set log level
 	log.SetLevel(log.DebugLevel)
 

--- a/scripts/tnd.sh
+++ b/scripts/tnd.sh
@@ -12,5 +12,5 @@ HTTP2="https://your.second.trusted.http.server.com:443"
 HASH2="SHA256 hash of HTTP2"
 SERV2="$HTTP2:$HASH2"
 
-go run ./cmd/tnd \
+go run ./examples/tnd \
 	-httpsservers "$SERV1,$SERV2"


### PR DESCRIPTION
The program in cmd/tnd and internal/cmd is rather an example than a real
application. So, move it to the examples folder.

Signed-off-by: hwipl <33433250+hwipl@users.noreply.github.com>